### PR TITLE
Bug fix vcrit vertical

### DIFF
--- a/pvtlib/fluid_mechanics.py
+++ b/pvtlib/fluid_mechanics.py
@@ -213,7 +213,7 @@ def critical_velocity_for_uniform_wio_dispersion_vertical(beta, ST_oil_aq, rho_o
     .. [1] NFOGM, Handbook of Water Fraction Metering. Revision 2 ed. 2004
     '''
     
-    if rho_o == 0 or Visc_o == 0 or beta == 100 or beta<0:
+    if rho_o == 0 or Visc_o == 0 or beta >= 100 or beta<0:
         Vc = np.nan
     else:
         Vc = K2 * ((beta ** 0.556) / ((100 - beta) ** 1.556)) * (ST_oil_aq ** 0.278) * (((rho_aq - rho_o) ** 0.278) / (rho_o ** 0.444)) * ((D / Visc_o) ** 0.111)

--- a/tests/test_fluid_mechanics.py
+++ b/tests/test_fluid_mechanics.py
@@ -146,4 +146,24 @@ def test_critical_velocity_for_uniform_wio_dispersion_vertical_3():
         )
     
     assert np.isnan(Vc), f'Critical velocity for homogeneous oil water mixture in a vertical pipe failed'    
+
+def test_critical_velocity_for_uniform_wio_dispersion_vertical_1():
+    '''
+    Test calculation of critical (minimum) velocity for maintaining homogeneous oil water mixture in a vertical pipe. 
+    Test is based on example from NFOGM Handbook of Water Fraction Metering Revision 2, December 2004, Appendix A
+    
+    Test with Betha > 100 vol%, should return nan
+    '''
+    
+    
+    Vc = fluid_mechanics.critical_velocity_for_uniform_wio_dispersion_vertical(
+        beta=300.0, 
+        ST_oil_aq=0.025, 
+        rho_o=800,
+        rho_aq=1025, 
+        Visc_o=0.005, 
+        D=0.1016
+        )
+    
+    assert np.isnan(Vc), f'Critical velocity for homogeneous oil water mixture in a vertical pipe failed'
     

--- a/tests/test_fluid_mechanics.py
+++ b/tests/test_fluid_mechanics.py
@@ -147,7 +147,7 @@ def test_critical_velocity_for_uniform_wio_dispersion_vertical_3():
     
     assert np.isnan(Vc), f'Critical velocity for homogeneous oil water mixture in a vertical pipe failed'    
 
-def test_critical_velocity_for_uniform_wio_dispersion_vertical_1():
+def test_critical_velocity_for_uniform_wio_dispersion_vertical_4():
     '''
     Test calculation of critical (minimum) velocity for maintaining homogeneous oil water mixture in a vertical pipe. 
     Test is based on example from NFOGM Handbook of Water Fraction Metering Revision 2, December 2004, Appendix A


### PR DESCRIPTION
Fix issue when beta > 100 (vol% water in oil), in which the Vcrit function returns a complex number. In the fix it returns nan instead. 